### PR TITLE
Delete inventory.ini

### DIFF
--- a/inventory.ini
+++ b/inventory.ini
@@ -1,9 +1,0 @@
-# Pass me as an argument to tell ansible which is which
-# e.g "anisble-playbook -i inventory.ini playbooks/ctrl.yml -e "num workers=2~"" will run only on the ctrl node, general.yml would run on all
-
-[ctrl]
-127.0.0.1 ansible_port=2222 ansible_user=vagrant 
-
-[nodes]
-192.168.56.101 ansible_port=2200 ansible_user=vagrant 
-192.168.56.102 ansible_port=2201 ansible_user=vagrant 


### PR DESCRIPTION
This deletes inventory.ini, it is no longer needed since now the Vagrantfile provides all the necessary config