### PR TITLE
Add volume mount for model caching in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,15 +2,18 @@ services:
   model-service:
     image: ghcr.io/doda2025-team14/model-service:latest
     restart: always
+    environment:
+      - MODEL_DIR=/app/model_files
+    volumes:
+      - model-files:/app/model_files
 
   app:
     image: ghcr.io/doda2025-team14/app:latest
     restart: always
     ports:
       - "${HOST_PORT:-8080}:8080"
-
     environment:
       - MODEL_HOST=http://model-service:8081
-  
 
-    
+volumes:
+  model-files:


### PR DESCRIPTION
This PR adds the following to docker-compose.yml:
1.  MODEL_DIR env var - This is so that the dir is consistent when the default directory changes and also is a bit more self-descriptive of its purpose
2.  model_files volume - This is the actual volume used as a cache between runs

To test, perform the following:
```bash
docker compose up
# notice it downloads the model & detach 
d
docker compose down
docker compose up
# now instead of downloading the model again, it should read the cache.
```

Closes #105 